### PR TITLE
Add Multithreading to render engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SRCDIR := ./src
 FILES = $(shell find $(SRCDIR) -name "*.cpp")
 ERR_FLAGS = -pedantic -Wall -Wextra
-C_FLAG = -O3 -I./Eigen/Eigen -std=gnu++17
+C_FLAG = -O3 -I./Eigen/Eigen -std=gnu++17 -pthread
 EXE_NAME = raytracer
 all:
 	g++ $(ERR_FLAGS) $(C_FLAG) $(FILES) -o $(EXE_NAME)

--- a/Scenes/basic_cube/driver00.txt
+++ b/Scenes/basic_cube/driver00.txt
@@ -6,4 +6,4 @@ bounds -2 -2 2 2
 res 512 512
 ambient 0.2 0.2 0.2
 light 10 10 100 1 0.5 0.5 0.5
-model 1.0 1.0 0.0 30 2 0.0 0.0 -15.0 cube_centered.obj
+model 1.0 1.0 0.0 30 2 0.0 0.0 -15.0 smooth cube_centered.obj

--- a/src/AnimatedObject.cpp
+++ b/src/AnimatedObject.cpp
@@ -99,15 +99,15 @@ SceneObject* AnimatedObject::get_object(){
 void AnimatedObject::advance_frame(){
     // Load the next model in the directory if there are any left
     if (has_next_frame()){
-          frame_setting this_transform = frame_steps[current_frame];
-          Transformation frame_transform(this_transform.transform_floats);
-          delete current_obj;
-          current_obj = new Model(*original_obj);
-          frame_transform.transform_object(current_obj);
-          if (this_transform.set_as_new_base_model){
-              delete original_obj;
-              original_obj = new Model(*current_obj);
-          }
+        frame_setting this_transform = frame_steps[current_frame];
+        Transformation frame_transform(this_transform.transform_floats);
+        delete current_obj;
+        current_obj = new Model(*original_obj);
+        frame_transform.transform_object(current_obj);
+        if (this_transform.set_as_new_base_model){
+            delete original_obj;
+            original_obj = new Model(*current_obj);
+        }
 
         current_frame++;
     }

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -67,7 +67,6 @@ void Image::save_image(std::string file_name){
     }
 
     output << "P3" << "\n";
-    std::cout << "Image_wid: " << orig_width << "\n";
     output << orig_width << " " << orig_height << " 255" << "\n";
     int red, green, blue;
     for (int i=orig_height-1;i>=0; i--){

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -32,7 +32,7 @@ Model::Model(){}
 void Model::load_model(){
     std::ifstream in(original_file);
     if (!in){
-        std::cerr << "Could not open " << original_file << std::endl;
+        std::cerr << "Could not open model file " << original_file << std::endl;
         load_successful = false;
         return;
     }

--- a/src/RenderImage.cpp
+++ b/src/RenderImage.cpp
@@ -2,12 +2,11 @@
 
 RenderImage::RenderImage(Scene* attached_scene){
     scene = attached_scene;
-}
-
-void RenderImage::render_image(std::string save_image_file){
     scene->reset_image();
     image_tiles = tile_images(128);
-    render_tiles();
+}
+
+void RenderImage::save_image(std::string save_image_file){
     scene->get_image().save_image(save_image_file);
 }
 

--- a/src/RenderImage.cpp
+++ b/src/RenderImage.cpp
@@ -2,6 +2,11 @@
 
 RenderImage::RenderImage(Scene* attached_scene){
     scene = attached_scene;
+    reset();
+}
+
+void RenderImage::reset(){
+    //  After each render this needs to be called before the next render
     scene->reset_image();
     image_tiles = tile_images(128);
 }

--- a/src/RenderImage.h
+++ b/src/RenderImage.h
@@ -1,6 +1,8 @@
 #ifndef RENDERIMAGE_INCLUDED
 #define RENDERIMAGE_INCLUDED
 #include <queue>
+#include<thread>
+#include<vector>
 
 #include "Scene.h"
 
@@ -20,14 +22,14 @@ struct image_tile{
 class RenderImage {
   public:
         RenderImage(Scene* attached_scene);
-        void render_image(std::string save_image_file);
+        void render_tiles();
+        void save_image(std::string save_image_file);
   private:
         Scene* scene;
         double MISSED_T_VALUE = 1000000000;
         std::queue<image_tile> image_tiles;
 
         std::queue<image_tile> tile_images(int window_size);
-        void render_tiles();
         void render_tile(image_tile img_t);
         void ray_trace(Ray& ray, Eigen::Vector3d& accum, Eigen::Vector3d& ampl, int level, double &t_value);
         double find_intersection(Ray& ray, SceneObject*& md, Eigen::Vector3d &hit_normal);

--- a/src/RenderImage.h
+++ b/src/RenderImage.h
@@ -1,8 +1,9 @@
 #ifndef RENDERIMAGE_INCLUDED
 #define RENDERIMAGE_INCLUDED
 #include <queue>
-#include<thread>
-#include<vector>
+#include <thread>
+#include <vector>
+#include <mutex>
 
 #include "Scene.h"
 
@@ -29,7 +30,9 @@ class RenderImage {
         Scene* scene;
         double MISSED_T_VALUE = 1000000000;
         std::queue<image_tile> image_tiles;
+        std::mutex image_tiles_mutex;
 
+        image_tile build_image_tile(int x, int y, int x_len, int y_len);
         std::queue<image_tile> tile_images(int window_size);
         void render_tile(image_tile img_t);
         void ray_trace(Ray& ray, Eigen::Vector3d& accum, Eigen::Vector3d& ampl, int level, double &t_value);

--- a/src/RenderImage.h
+++ b/src/RenderImage.h
@@ -22,6 +22,7 @@ struct image_tile{
 class RenderImage {
   public:
         RenderImage(Scene* attached_scene);
+        void reset();
         void render_tiles();
         void save_image(std::string save_image_file);
   private:

--- a/src/RenderImage.h
+++ b/src/RenderImage.h
@@ -1,11 +1,21 @@
 #ifndef RENDERIMAGE_INCLUDED
 #define RENDERIMAGE_INCLUDED
+#include <queue>
 
 #include "Scene.h"
 
 // Needs to link Eigen in the makefile with g++ -I/path/to/Eigen
 #include <Eigen>
 #include <Core>
+
+struct image_tile{
+    // Defines a window in the image plane, assists the split of the total render
+    // into smaller parts
+    int x;
+    int y;
+    int x_len;
+    int y_len;
+};
 
 class RenderImage {
   public:
@@ -14,8 +24,11 @@ class RenderImage {
   private:
         Scene* scene;
         double MISSED_T_VALUE = 1000000000;
+        std::queue<image_tile> image_tiles;
 
-        void shoot_rays();
+        std::queue<image_tile> tile_images(int window_size);
+        void render_tiles();
+        void render_tile(image_tile img_t);
         void ray_trace(Ray& ray, Eigen::Vector3d& accum, Eigen::Vector3d& ampl, int level, double &t_value);
         double find_intersection(Ray& ray, SceneObject*& md, Eigen::Vector3d &hit_normal);
         void calculate_color(Ray& ray, double t_value, SceneObject* hit_obj, Eigen::Vector3d &hit_normal, Eigen::Vector3d &accum, Eigen::Vector3d &ampl, int level);

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -44,9 +44,9 @@ void Scene::reset_image(){
 }
 
 bool Scene::advance_frame(){
-    std::cout << "current: " << current_frame << " out of: " << number_frames << "\n";
     // Call to make the necessary changes to the scene before rendering the next frame
     if (has_next_frame()){
+        std::cout << "current frame: " << current_frame << " out of: " << number_frames << "\n";
         render_objects.clear();
         for (auto ao:animated_objects){
             ao->advance_frame();
@@ -57,9 +57,8 @@ bool Scene::advance_frame(){
         }
         current_frame++;
         return true;
-    } else{
-        return false;
     }
+    return false;
 }
 
 bool Scene::has_next_frame(){
@@ -149,9 +148,9 @@ void Scene::edit_camera(std::string driver_line){
         d_line >> d1 >> d2 >> d3;
         destination_image.set_focus_blur(d1, d2, d3);
     }else if(!driver_line.compare(0, anti_alias.size(), anti_alias)){
-          d_line >> d1;
-          scene_camera.set_anti_alias(d1);
-          destination_image.set_anti_alias(d1);
+        d_line >> d1;
+        scene_camera.set_anti_alias(d1);
+        destination_image.set_anti_alias(d1);
     }else if(!driver_line.compare(0, recursion.size(), recursion)){
         d_line >> recursion_level;
     }else if(!driver_line.compare(0, frames.size(), frames)) {

--- a/src/SceneObject.cpp
+++ b/src/SceneObject.cpp
@@ -63,7 +63,7 @@ void SceneObject::load_material(std::string material_file){
     std::ifstream in(material_file);
     std::cout << "LOADING MATERIAL: " << material_file << "\n";
     if (!in){
-        std::cerr << "Could not open " << material_file << std::endl;
+        std::cerr << "Could not open material file " << material_file << std::endl;
         return;
     }
     std::string obj_line;

--- a/src/SceneObject.cpp
+++ b/src/SceneObject.cpp
@@ -61,7 +61,6 @@ bool SceneObject::model_loaded(){
 
 void SceneObject::load_material(std::string material_file){
     std::ifstream in(material_file);
-    std::cout << "LOADING MATERIAL: " << material_file << "\n";
     if (!in){
         std::cerr << "Could not open material file " << material_file << std::endl;
         return;

--- a/src/Transformation.cpp
+++ b/src/Transformation.cpp
@@ -31,6 +31,8 @@ Transformation::Transformation(std::string driver_string){
     driver >> asset_name;
     driver >> lighting_group;
     driver >> animation_file;
+    if (asset_name.length() == 0)
+        std::cout << "Invalid driver_string: " << driver_string << std::endl;
 }
 
 Transformation::Transformation(std::vector<double> transform_floats){

--- a/src/raytracer.cpp
+++ b/src/raytracer.cpp
@@ -7,7 +7,11 @@ void create_directory(std::string save_folder){
     // Clear the saved render folder of previous contents
     char remove_command[80] = "rm -r ";
     strcat(remove_command, save_folder.c_str());
-    system(remove_command);
+    if (0 == system(remove_command)){
+        // The result of this command does not need to be handled as the following system command
+        //   properly alerts to the same potential problem set.
+        ;
+    }
 
     char create_command[80] = "mkdir ";
     strcat(create_command, save_folder.c_str());

--- a/src/raytracer.cpp
+++ b/src/raytracer.cpp
@@ -2,63 +2,123 @@
 #include "Scene.h"
 #include "RenderImage.h"
 
-std::string SAVE_FOLDER = "./tmp_renders/";
+void create_directory(std::string save_folder){
+    //   ***** THIS USES LINUX SYSTEM CALLS, TO RUN ON WINDOWS REWRITE ******
+    // Clear the saved render folder of previous contents
+    char remove_command[80] = "rm -r ";
+    strcat(remove_command, save_folder.c_str());
+    system(remove_command);
 
-std::string strip_file_ending(std::string original){
-    std::size_t found = original.find(".");
-    if (found != std::string::npos){
-        original = original.substr(0, found);
+    char create_command[80] = "mkdir ";
+    strcat(create_command, save_folder.c_str());
+    if (0 == system(create_command)){
+        std::cout << save_folder << " directory created successfully\n";
+    } else{
+        std::cout << save_folder << " directory creation failed\n";
     }
-    return original;
 }
 
-void prepare_directory(){
-    // Clear the saved render folder of previous contents
-    std::cout << "Removing " << SAVE_FOLDER << " directory\n";
-    char remove_command[80] = "rm -r ";
-    strcat(remove_command, SAVE_FOLDER.c_str());
-    if (0 == system(remove_command)){
-        std::cout << "Directory removal successful\n";
+int parse_int(std::string str, int &status){
+    int result = 0;
+    try {
+        result = stoi(str);
     }
+    catch(std::invalid_argument& e){
+        status = 1;
+    }
+    return result;
+}
 
-    std::cout << "Creating " << SAVE_FOLDER << " directory\n";
-    char create_command[80] = "mkdir ";
-    strcat(create_command, SAVE_FOLDER.c_str());
-    if (0 == system(create_command)){
-        std::cout << "Directory creation successful\n";
+std::string parse_folder_name(std::string name){
+    std::string result = "";
+    for (auto c: name){
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')){
+            result += c;
+        }
+    }
+    return result;
+}
+
+int parse_args(int argc, char*argv[], int &num_threads, std::string &driver_file, std::string &save_folder){
+    int status = 0;
+
+    // Set Defaults
+    num_threads = 1;
+
+    // Parse flags
+    for (int i=1; i<argc-2; i++){
+        std::string arg = argv[i];
+        if (arg == "-t" || arg == "--threads"){
+            int valid_int = 0;
+            num_threads = parse_int(std::string(argv[++i]), valid_int);
+            if (valid_int != 0 || (!(i < argc-2))){
+                std::cout << "Number of threads not specified\n";
+                status = 1;
+                num_threads = 1;
+            } else{
+                num_threads = std::max(std::min(num_threads, 100), 1);
+            }
+        }
+    }
+    if (!(argc >= 3)){
+        status = 1;
+    }
+    // Extract two mandatory arguments
+    if (status == 0){
+        driver_file = argv[argc-2];
+        save_folder = parse_folder_name(argv[argc-1]);
     } else{
-        std::cout << "Directory creation failed\n";
+        std::cout << "Error: run with " << argv[0] << " <driver_file> <save_folder>\n\n"
+                  << "    driver_file: A scene specification file, more detail in scene_driver.md\n"
+                  << "    save_folder: The folder to save output images to. If it already exists current\n"
+                  << "        contents will be replaced\n\n"
+                  << "    Optional:\n"
+                  << "         --threads, -t  specify number of threads\n\n";
+    }
+    return status;
+}
+
+std::string image_name(int frame_number, std::string save_folder){
+    std::string padded_frame_num = std::to_string(frame_number);
+    while (padded_frame_num.size() < 4){
+        padded_frame_num = "0" + padded_frame_num;
+    }
+    std::string result = save_folder + "/output" + padded_frame_num + ".ppm";
+    return result;
+}
+
+void multi_thread_render(RenderImage &ri, int number_threads){
+    std::vector<std::thread> render_threads;
+    for (int i=0; i<number_threads; i++)
+        render_threads.push_back(std::thread(&RenderImage::render_tiles, &ri));
+
+    for (std::thread & t : render_threads)
+        t.join();
+}
+
+void render_scene(Scene &sc, int number_threads, std::string save_folder){
+    RenderImage ri = RenderImage(&sc);
+    while (sc.advance_frame()){
+        ri.reset();
+        if (number_threads > 1)
+            multi_thread_render(ri, number_threads);
+        else
+            ri.render_tiles();
+        ri.save_image(image_name(sc.get_current_frame(), save_folder));
     }
 }
 
 int main(int argc, char*argv[]){
-    if (argc != 3){
-        std::cout << "Error: run with " << argv[0] << " <driver_file> <save_image_file>" << std::endl;
-        return 1;
+    int number_threads = 1;
+    std::string driver_file = "";
+    std::string save_folder = "";
+    int valid_args = parse_args(argc, argv, number_threads, driver_file, save_folder);
+    if (valid_args != 0){
+        return valid_args;
     }
-    std::string driver_file = argv[1];
-    std::string save_image_file = argv[2];
 
+    create_directory(save_folder);
     Scene sc(driver_file);
-    prepare_directory();
-    save_image_file = strip_file_ending(save_image_file);
-
-    while (sc.advance_frame()){
-        std::string padded_frame_num = std::to_string(sc.get_current_frame());
-        while (padded_frame_num.size() < 4){
-            padded_frame_num = "0" + padded_frame_num;
-        }
-        std::string image_name = SAVE_FOLDER + save_image_file + padded_frame_num + ".ppm";
-        RenderImage ri = RenderImage(&sc);
-
-        std::vector<std::thread> render_threads;
-        for (int i=0; i<4; i++)
-          render_threads.push_back(std::thread(&RenderImage::render_tiles, &ri));
-
-        for (std::thread & t : render_threads)
-          t.join();
-
-        ri.save_image(image_name);
-    }
+    render_scene(sc, number_threads, save_folder);
     return 0;
 }

--- a/src/raytracer.cpp
+++ b/src/raytracer.cpp
@@ -50,7 +50,15 @@ int main(int argc, char*argv[]){
         }
         std::string image_name = SAVE_FOLDER + save_image_file + padded_frame_num + ".ppm";
         RenderImage ri = RenderImage(&sc);
-        ri.render_image(image_name);
+
+        std::vector<std::thread> render_threads;
+        for (int i=0; i<4; i++)
+          render_threads.push_back(std::thread(&RenderImage::render_tiles, &ri));
+
+        for (std::thread & t : render_threads)
+          t.join();
+
+        ri.save_image(image_name);
     }
     return 0;
 }


### PR DESCRIPTION
Rendering an image has been split into rendering smaller tiles. These tiles are generated, and then stored in a queue. Multiple threads can pop from the queue and concurrently ray trace separate parts of the final image.

The number of threads is specified with the flag -t or --threads